### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ th.value(); // => 4
 
 // Sum Types
 var Maybe = new Variant({
-    Just: (value) => ({value: value}),
+    Just: (value) => ({value}),
     Nothing: () => ({})
 });
 Maybe.pure = Maybe.Just;


### PR DESCRIPTION
Since you're examples are ES6 code you can use shorthand {prop} instead of {prop: prop}.